### PR TITLE
Build and publish a docs preview for each pull request

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -61,7 +61,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > pr_sha.txt
 
       - name: Upload preview artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr-preview
           path: |

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,72 @@
+name: Build PR preview
+
+# Builds a documentation preview for a pull request. This job runs with a
+# read-only token and NEVER touches the gh-pages branch, so it is safe even for
+# untrusted (fork) PRs. The actual publish happens in the companion workflow
+# "Deploy PR preview" (pr-preview-deploy.yml), which runs with a write token via
+# workflow_run. This build/deploy split lets us support fork PRs in the future
+# by simply relaxing the same-repo guard below.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Only build PRs from the same repository for now. Fork PRs could inject content
+# into the published docs, so they are intentionally excluded. Remove this guard
+# (and review the trust model) to enable previews for forks later.
+permissions:
+  contents: read
+
+concurrency:
+  # Supersede in-flight builds for the same PR.
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -U -r requirements.txt
+
+      - name: Build PR preview
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_SHA_FULL: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Derive the host from docs/CNAME so this works on both the production
+          # repo (docs.3dcitydb.org) and the bwibo testing fork
+          # (docs.brunowillenborg.de) without any change.
+          HOST="$(tr -d '[:space:]' < docs/CNAME 2>/dev/null || echo docs.3dcitydb.org)"
+          export SITE_URL="https://${HOST}/pr/${PR_NUMBER}/"
+          export PR_SHA="${PR_SHA_FULL:0:7}"
+          echo "Building preview at $SITE_URL (commit $PR_SHA)"
+          mkdocs build -f mkdocs.pr.yml -d site --strict
+
+      - name: Record PR metadata for deploy job
+        run: |
+          echo "${{ github.event.number }}" > pr_number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > pr_sha.txt
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview
+          path: |
+            site
+            pr_number.txt
+            pr_sha.txt
+          retention-days: 3
+          if-no-files-found: error

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,73 @@
+name: Cleanup PR previews
+
+# Weekly sweep that removes pr/<num>/ preview folders from gh-pages whose pull
+# request is no longer open (closed, merged, or deleted). Runs on a schedule
+# only; there is no on-close trigger by design.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  # Shared with ci.yml and pr-preview-deploy.yml to avoid racing on gh-pages.
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+
+      - name: Remove previews of closed/merged PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ ! -d pr ]; then
+            echo "No pr/ directory; nothing to clean."
+            exit 0
+          fi
+          removed=0
+          for dir in pr/*/; do
+            [ -d "$dir" ] || continue
+            num="$(basename "$dir")"
+            if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+              echo "Skipping non-numeric entry: $dir"
+              continue
+            fi
+            # Treat any non-OPEN state, or a PR that no longer exists, as stale.
+            state="$(gh pr view "$num" --json state -q .state 2>/dev/null || echo MISSING)"
+            if [ "$state" = "OPEN" ]; then
+              echo "PR #$num is open; keeping preview."
+            else
+              echo "PR #$num is $state; removing $dir"
+              rm -rf "$dir"
+              removed=$((removed + 1))
+            fi
+          done
+          echo "Removed $removed preview(s)."
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No stale previews to remove."
+            exit 0
+          fi
+          git commit -m "docs: clean up previews of closed/merged PRs"
+          git push origin gh-pages || {
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            git push origin gh-pages
+          }

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,119 @@
+name: Deploy PR preview
+
+# Publishes the artifact produced by "Build PR preview" into pr/<num>/ on the
+# gh-pages branch and posts/updates a preview link on the PR. This runs via
+# workflow_run so it has a write token even though the build job did not — the
+# build job never sees secrets, which keeps the door open for fork PRs later.
+#
+# This job only copies the already-built static site into gh-pages; it never
+# executes PR code. It also NEVER touches versions.json, so PR previews do not
+# appear in the mike version menu.
+
+on:
+  workflow_run:
+    workflows: ["Build PR preview"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read # required to download the build artifact from the triggering run
+
+concurrency:
+  # Shared with ci.yml (mike deploys) and the cleanup workflow so that no two
+  # jobs push to gh-pages at the same time.
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: artifact
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          PR="$(cat artifact/pr_number.txt)"
+          SHA="$(cat artifact/pr_sha.txt)"
+          # Harden against a tampered artifact: PR number must be digits only.
+          if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: '$PR'" >&2
+            exit 1
+          fi
+          # Use the host the site was actually built with (from its CNAME) so the
+          # comment link is correct on both the production repo and the fork.
+          HOST="$(tr -d '[:space:]' < artifact/site/CNAME 2>/dev/null || echo docs.3dcitydb.org)"
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "host=$HOST" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Update preview folder
+        run: |
+          PR="${{ steps.meta.outputs.pr }}"
+          rm -rf "gh-pages/pr/$PR"
+          mkdir -p "gh-pages/pr/$PR"
+          cp -r artifact/site/. "gh-pages/pr/$PR/"
+
+      - name: Commit and push
+        run: |
+          cd gh-pages
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add "pr/${{ steps.meta.outputs.pr }}"
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git commit -m "docs: preview for PR #${{ steps.meta.outputs.pr }} (${{ steps.meta.outputs.sha }})"
+          # Serialized by the docs-deploy concurrency group; rebase is a safety net.
+          git push origin gh-pages || {
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            git push origin gh-pages
+          }
+
+      - name: Comment preview link on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = Number('${{ steps.meta.outputs.pr }}');
+            const sha = '${{ steps.meta.outputs.sha }}';
+            const host = '${{ steps.meta.outputs.host }}';
+            const url = `https://${host}/pr/${pr}/`;
+            const marker = '<!-- pr-preview-bot -->';
+            const body = [
+              marker,
+              '### 📖 Documentation preview ready',
+              '',
+              'Preview for this PR is live at:',
+              `**${url}**`,
+              '',
+              `Built from ${sha}. Updated automatically on every push. ` +
+              'Removed automatically after the PR is closed.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            }

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download preview artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pr-preview
           run-id: ${{ github.event.workflow_run.id }}
@@ -89,7 +89,7 @@ jobs:
           }
 
       - name: Comment preview link on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = Number('${{ steps.meta.outputs.pr }}');

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # Build dirs
 site/
+
+# Claude
+/.claude/

--- a/README.md
+++ b/README.md
@@ -104,3 +104,29 @@ To update documentation content for an existing release version:
 - Content updates preserve the existing version number and aliases
 - The documentation will be redeployed with the same version identifier
 - If updating the current `latest` version, the changes will be immediately visible on the default documentation site
+
+### PR preview builds
+
+Every pull request from a branch **within this repository** gets an ephemeral
+documentation preview so reviewers can see the rendered result before merging.
+
+- **URL**: `https://docs.3dcitydb.org/pr/<PR-number>/` — a bot comment with the link is
+  posted on the PR and updated on every push.
+- **Not in the version menu**: previews are published straight into the `pr/` folder on the
+  `gh-pages` branch and never touch `versions.json`, so they do **not** appear in the version
+  dropdown at the top of the docs. They also carry a preview banner and are marked `noindex`.
+- **Automatic cleanup**: a scheduled job removes previews of closed/merged PRs **once a week**
+  (Mondays), and can also be run manually via *workflow_dispatch*.
+- **Fork PRs are excluded** for now (a fork could inject content into the docs site).
+
+The feature is implemented as a build/deploy split so it can be extended to forks later:
+
+- `.github/workflows/pr-preview-build.yml` — builds the preview with `mkdocs.pr.yml` using a
+  **read-only** token (safe for untrusted code) and uploads it as an artifact.
+- `.github/workflows/pr-preview-deploy.yml` — publishes the artifact to `gh-pages` under
+  `pr/<num>/` and comments on the PR, using a **write** token via `workflow_run`.
+- `.github/workflows/pr-preview-cleanup.yml` — the weekly cleanup sweep.
+
+`mkdocs.pr.yml` is a small overlay over `mkdocs.yml` (via `INHERIT`) that injects the per-PR
+`site_url`, enables the `overrides/main.html` banner, and hides the version selector — the
+production build (`mkdocs.yml`) is unchanged.

--- a/mkdocs.pr.yml
+++ b/mkdocs.pr.yml
@@ -1,0 +1,21 @@
+# PR preview build config #####################################################
+# Overlay used ONLY for per-PR preview builds (see .github/workflows/
+# pr-preview-build.yml). It inherits the production mkdocs.yml and overrides
+# just the bits a throwaway preview needs. Do not use this for real deploys.
+INHERIT: mkdocs.yml
+
+# Per-PR values are injected by CI via environment variables.
+site_url: !ENV [SITE_URL, "https://docs.3dcitydb.org/"]
+
+theme:
+  # Only PR builds pull in the preview banner override.
+  custom_dir: overrides
+
+extra:
+  pr_number: !ENV [PR_NUMBER, ""]
+  pr_url: !ENV [PR_URL, ""]
+  pr_sha: !ENV [PR_SHA, ""]
+  # Hide the mike version selector in previews: there is no versions.json
+  # under /pr/<num>/, so a selector would be broken. Replacing the dict from
+  # mkdocs.yml with `false` makes Material render no version dropdown.
+  version: false

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+<!--
+  PR preview banner. Only active when built with mkdocs.pr.yml (which sets
+  theme.custom_dir: overrides and extra.pr_number). Production builds never
+  use this template, so the official docs are unaffected.
+-->
+
+{% block announce %}
+  {% if config.extra.pr_number %}
+  <a href="{{ config.extra.pr_url }}" style="font-weight: 600;">
+    🔍 Preview of pull request #{{ config.extra.pr_number }}{% if config.extra.pr_sha %} (commit {{ config.extra.pr_sha }}){% endif %} — not the official documentation.
+  </a>
+  {% endif %}
+{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if config.extra.pr_number %}
+  <meta name="robots" content="noindex, nofollow">
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## What

Adds an ephemeral **per-PR documentation preview** so reviewers can see rendered changes before merging.

- **URL:** `https://docs.3dcitydb.org/pr/<PR-number>/` — a bot comment posts the link and updates it on every push.
- **Not in the version menu:** previews go into a `pr/` folder on `gh-pages` and never touch `versions.json`, so they do not appear in the mike version dropdown. They also carry a preview banner (with short commit hash) and are marked `noindex`.
- **Automatic cleanup:** a scheduled job removes previews of closed/merged PRs weekly (also runnable via *workflow_dispatch*).
- **Fork PRs excluded for now** (a fork could inject content into the docs site).

## How

Implemented as a build/deploy split so fork support is a one-line change later:

- `.github/workflows/pr-preview-build.yml` — builds with `mkdocs.pr.yml` using a **read-only** token, uploads an artifact.
- `.github/workflows/pr-preview-deploy.yml` — publishes the artifact to `gh-pages` under `pr/<num>/` and comments on the PR, using a **write** token via `workflow_run`.
- `.github/workflows/pr-preview-cleanup.yml` — weekly cleanup sweep.
- `mkdocs.pr.yml` — small `INHERIT` overlay over `mkdocs.yml` (per-PR `site_url`, banner, version selector hidden). Production build is unchanged.
- `overrides/main.html` — preview banner + `noindex`.

The existing `ci.yml` (mike-based edge/release deploys) is untouched, and all three workflows share the `docs-deploy` concurrency group so nothing races on `gh-pages`.

Tested end-to-end on a fork (build → deploy → bot comment → weekly cleanup lifecycle all verified).

## Demo

A demo is online in my personal fork.

- https://github.com/BWibo/3dcitydb-mkdocs/pull/2
- https://docs.brunowillenborg.de/pr/2/