### PR TITLE
ci: update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Final version: $VERSION"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -126,7 +126,7 @@ jobs:
 
       - name: Create or update GitHub release
         if: startsWith(github.ref, 'refs/heads/release-')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "v${{ steps.version.outputs.version }}"
           name: "Release v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Why

GitHub Actions runners now default to **Node.js 24** (since 2026-06-16) and the Node.js 20 runtime is being removed (2026-09-16). Actions in `ci.yml` that still declare `node20` emit the deprecation warning.

## What

Bump the offending actions in `ci.yml` to their Node 24 native major versions (verified against each target tag's `action.yml` `runs.using: node24`):

| Action | Old | New |
|---|---|---|
| actions/setup-python | v5 | v6 |
| softprops/action-gh-release | v2 | v3 |

`actions/checkout@v5` already runs on node24 → unchanged.

> Note: the `pr-preview-*.yml` workflows (upload/download-artifact, github-script, setup-python) live only on the `feature/pr-preview-builds` branch; their equivalent Node 24 bumps have been pushed to that branch so its own PR carries them.

## Validation

- YAML parsed; `actionlint` clean (only pre-existing informational SC2086 notes in unrelated `run:` steps).